### PR TITLE
[Fix] #52 Cart, OrderDetail 네트워킹 의존성주입

### DIFF
--- a/BeaMin-iOS/BeaMin-iOS/Presenter/Cart/Manager/CartManager.swift
+++ b/BeaMin-iOS/BeaMin-iOS/Presenter/Cart/Manager/CartManager.swift
@@ -11,7 +11,13 @@ import Alamofire
 
 import CustomExtension
 
-final class CartManager {
+protocol CartManagerNetwork: AnyObject {
+    func fetchCartDTO(completion: @escaping (CartModelDTO) -> Void)
+    func deleteCartMenu(menuID: Int)
+    func orderComplete(cartID: Int, completion: @escaping (Bool)->Void)
+}
+
+final class CartManager: CartManagerNetwork {
     static let shared = CartManager()
     private init() {}
     

--- a/BeaMin-iOS/BeaMin-iOS/Presenter/Cart/ViewController/CartViewController.swift
+++ b/BeaMin-iOS/BeaMin-iOS/Presenter/Cart/ViewController/CartViewController.swift
@@ -16,7 +16,7 @@ import DesignSystem
 
 final class CartViewController: UIViewController {
     
-    private let cartManager = CartManager.shared
+    private let cartManager: CartManagerNetwork
     
     private var cartData: CartModelDTO = .init(cartID: 0, totalDeliveryTip: 0, menusByStore: []) {
         didSet {
@@ -33,6 +33,15 @@ final class CartViewController: UIViewController {
                                                         frame: .init(x: 0, y: 0, width: Constant.Screen.width, height: 400))
     
     private lazy var cartButton = CartInfoButton(totalPrice: cartData.totalPrice + cartData.totalDeliveryTip, totalCount: cartData.totalMenuCount)
+    
+    init(cartManager: CartManagerNetwork) {
+        self.cartManager = cartManager
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/BeaMin-iOS/BeaMin-iOS/Presenter/OrderDetail/Manager/OrderDetailManager.swift
+++ b/BeaMin-iOS/BeaMin-iOS/Presenter/OrderDetail/Manager/OrderDetailManager.swift
@@ -11,11 +11,15 @@ import Alamofire
 
 import CustomExtension
 
-final class OrderDetailManager {
+protocol OrderDetailNetwork: AnyObject {
+    func appendMenuInCart(cartID: Int, storeID: Int, menuName: String, menuImage: String, totalPrice: Int, options: String, totalCount: Int, completion: @escaping (Bool) -> Void)
+}
+
+final class OrderDetailManager: OrderDetailNetwork {
     static let shared = OrderDetailManager()
     private init() {}
     
-    func appendMenuInCart(cartID: Int, storeID: Int = 1, menuName: String, menuImage: String, totalPrice: Int, options: String, totalCount: Int, completion: @escaping (Bool)->Void) {
+    func appendMenuInCart(cartID: Int, storeID: Int = 1, menuName: String, menuImage: String, totalPrice: Int, options: String, totalCount: Int, completion: @escaping (Bool) -> Void) {
         let dataRequest = AF.request(Constant.CartNetworkConstant.baseURL, method: .post, parameters: makeRequestBody(cartID: cartID, menuName: menuName, menuImage: menuImage, totalPrice: totalPrice, options: options, totalCount: totalCount), encoding: JSONEncoding.default)
         dataRequest.responseData { response in
             switch response.result {

--- a/BeaMin-iOS/BeaMin-iOS/Presenter/OrderDetail/ViewController/OrderDetailViewController.swift
+++ b/BeaMin-iOS/BeaMin-iOS/Presenter/OrderDetail/ViewController/OrderDetailViewController.swift
@@ -105,7 +105,7 @@ private extension OrderDetailViewController {
                 let options = "데이터연결 아직안함"
                 OrderDetailManager.shared.appendMenuInCart(cartID: cartID, menuName: menuTitle, menuImage: menuImage, totalPrice: totalPrice, options: options, totalCount: menuCount) { isCompleted in
                     if isCompleted {
-                        let cartViewController = CartViewController()
+                        let cartViewController = CartViewController(cartManager: CartManager.shared)
                         self.navigationController?.pushViewController(cartViewController, animated: true)
                     }
                 }


### PR DESCRIPTION
## 1. 의존성주입을 위한 추상화 
### CartManager
1. DIP를 위해 추상화된 객체를 생성
```swift
protocol CartManagerNetwork: AnyObject {
    func fetchCartDTO(completion: @escaping (CartModelDTO) -> Void)
    func deleteCartMenu(menuID: Int)
    func orderComplete(cartID: Int, completion: @escaping (Bool)->Void)
}
```

2. 해당프로토콜을 Manger객체가 채택하고
```swift
final class CartManager: CartManagerNetwork {}
```

3.해당 프토토콜을 따르는 객체를 외부에서 주입시켜줌(생성자를만들고 외부에서 주입)
```swift
init(cartManager: CartManagerNetwork) {
     self.cartManager = cartManager
    super.init(nibName: nil, bundle: nil)
}
```

```swift
let cartViewController = CartViewController(cartManager: CartManager.shared)
self.navigationController?.pushViewController(cartViewController, animated: true)
```

### OrderDetailManager
1. DIP를 위한 추상화된 객체를 생성
- 지금 서버를 닫아놓은 상태이고 이쪽 OrderViewController네트워킹이 연결이 안되있던 상황이라 네트워크 코드만 추상화를 통한 분리작업만 수행
```swift
protocol OrderDetailNetwork: AnyObject {
    func appendMenuInCart(cartID: Int, storeID: Int, menuName: String, menuImage: String, totalPrice: Int, options: String, totalCount: Int, completion: @escaping (Bool) -> Void)
}
```
protocol에는 parameter의 기본값 설정이 안된다는사실을 알게됨

2. 해당프로토콜을 Manger객체가 채택
```swift
final class OrderDetailManager: OrderDetailNetwork {}
```